### PR TITLE
Flat ids array

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 opencv-python==4.10.0.84
 opencv-contrib-python==4.10.0.84
 pyYAML==6.0.2
+numpy==2.1.1

--- a/src/domain/vision/aruco/aruco_detector.py
+++ b/src/domain/vision/aruco/aruco_detector.py
@@ -20,7 +20,7 @@ class ArucoDetector:
         return (
             [
                 self.__aruco_factory.create(identifier, corner)
-                for identifier, corner in zip(ids, corners)
+                for identifier, corner in zip(ids.flatten(), corners)
             ]
             if ids is not None
             else []

--- a/src/domain/vision/aruco/aruco_factory.py
+++ b/src/domain/vision/aruco/aruco_factory.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import numpy as np
 
 from src.domain.common.position import Position

--- a/src/domain/vision/aruco/aruco_factory.py
+++ b/src/domain/vision/aruco/aruco_factory.py
@@ -10,11 +10,11 @@ class ArucoFactory:
     def __init__(self):
         pass
 
-    def __create_position(self, corners: List) -> Position:
-        position_x: float = np.mean(corners[0][:, 0])
-        position_y: float = np.mean(corners[0][:, 0])
+    def __create_position(self, corners: np.ndarray) -> Position:
+        position_x = float(np.mean(corners[0][:, 0]))
+        position_y = float(np.mean(corners[0][:, 0]))
         return Position(position_x, position_y)
 
-    def create(self, identifier: int, corners: List) -> Aruco:
+    def create(self, identifier: int, corners: np.ndarray) -> Aruco:
         position = self.__create_position(corners)
         return Aruco(identifier, position)


### PR DESCRIPTION
We were printing the array all the time for the identifier. Flatten the `ids` array fix the issue.